### PR TITLE
chore: update package "rize/uri-template" to "^0.4.1"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "phpdocumentor/reflection-docblock": "^5.3",
         "react/async": "^4.0.0",
         "react/promise-timer": "^1.10",
-        "rize/uri-template": "^0.3.4",
+        "rize/uri-template": "^0.4.1",
         "symfony/clock": "^6.0|^7.0.0|^8.0.0",
         "symfony/console": "^6.0.0|^7.0.0|^8.0.0",
         "symfony/deprecation-contracts": "^3.1",


### PR DESCRIPTION
The BC break is the PHP version will be `>=8.1` so ok for Freddie.

It permits to remove the deprecation message:
```
   DEPRECATED  Tests\Unit\Helper\TopicHelperTest > it matches topics with ('/foo', [], false)
  Rize\UriTemplate::__construct(): Implicitly marking parameter $parser as nullable is deprecated, the explicit nullable type must be used instead

  at vendor/rize/uri-template/src/Rize/UriTemplate/UriTemplate.php:10
      6▕
      7▕ /**
      8▕  * Future compatibility
      9▕  */
  ➜  10▕ class UriTemplate extends Template
     11▕ {
     12▕ }
     13▕

  1   src/Helper/TopicHelper.php:71
  2   src/functions.php:22

  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   DEPRECATED  Tests\Unit\Helper\TopicHelperTest > it matches topics with ('/foo/bar', ['/foo/{bar}'], true)
  Rize\UriTemplate\Node\Expression::__construct(): Implicitly marking parameter $variables as nullable is deprecated, the explicit nullable type must be used instead

  at vendor/rize/uri-template/src/Rize/UriTemplate/Parser.php:144
    140▕     }
    141▕
    142▕     protected function createExpressionNode($token, Operator\Abstraction $operator = null, array $vars = array())
    143▕     {
  ➜ 144▕         return new Node\Expression($token, $operator, $vars);
    145▕     }
    146▕
    147▕     protected function createLiteralNode($token)
    148▕     {

```