### PR TITLE
ci: add compact option for tests

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -60,7 +60,7 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Run tests
-        run: vendor/bin/pest --testsuite='Unit tests' --coverage --coverage-clover=coverage.xml
+        run: vendor/bin/pest --testsuite='Unit tests' --compact --coverage --coverage-clover=coverage.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
@@ -104,5 +104,5 @@ jobs:
       - name: Run tests
         env:
           TRANSPORT_DSN: ${{ matrix.transport }}
-        run: vendor/bin/pest --testsuite='Integration tests'
+        run: vendor/bin/pest --testsuite='Integration tests' --compact
 


### PR DESCRIPTION
It permits to have a compact text for tests like:
```
Run vendor/bin/pest --testsuite='Unit tests' --compact --coverage --coverage-clover=coverage.xml
  
2026-02-13 13:46:58.386 Listening on http://127.0.0.1:8081
  !.......................................!!!!.!.....!.......2026-02-13 13:46:58.498 - "POST /.well-known/mercure HTTP/1.1" 201 26 0.000
2026-02-13 13:46:58.504 - "POST /.well-known/mercure HTTP/1.1" 201 26 0.000
2026-02-13 13:46:58.508 - "POST /.well-known/mercure HTTP/1.1" 403 54 0.000
2026-02-13 13:46:58.523 - "POST /.well-known/mercure HTTP/1.1" 503 0 0.000
2026-02-13 13:46:58.526 - "POST /.well-known/mercure HTTP/1.1" 504 0 0.000
.................
  ..2026-02-13 13:46:58.592 - "POST ./well-known/mercure HTTP/1.1" 200 0 0.000
2026-02-13 13:46:58.593 - "POST ./well-known/mercure HTTP/1.1" 200 0 0.000
..2026-02-13 13:46:58.596 - "POST ./well-known/mercure HTTP/1.1" 204 0 0.000
2026-02-13 13:46:58.596 - "POST ./well-known/mercure HTTP/1.1" 403 5 0.000
.2026-02-13 13:46:58.601 - "GET / HTTP/1.1" 204 0 0.000
2026-02-13 13:46:58.602 - "GET / HTTP/1.1" 204 0 0.000
...........ss..........................................................
  ...
  Tests:    7 deprecated, 2 skipped, 146 passed (211 assertions)
  Duration: 0.57s
  ────────────────────────────────────────────────────────────────────────────  
                                                                Total: 100.0 %  
```