### PR TITLE
chore: use last tag for Framework X package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-ctype": "*",
         "ext-iconv": "*",
         "bentools/querystring": "^1.1",
-        "clue/framework-x": "dev-main#cfe017426d8acc7a92b5893a501728e034a873cc",
+        "clue/framework-x": "^0.17",
         "clue/redis-react": "^2.5",
         "doctrine/annotations": "^1.0",
         "lcobucci/jwt": "^5.5",


### PR DESCRIPTION
I set the last tag for Framework X (`0.17`) instead of using a [old commit](https://github.com/clue/framework-x/commit/cfe017426d8acc7a92b5893a501728e034a873cc) from main.

But it seems since the [next commit](https://github.com/clue/framework-x/commit/c8a4cdf7b5eb8b104e731edda59fb674ed5d35d1) and the version [`0.8`](https://github.com/clue/framework-x/releases/tag/v0.8.0), the tests remains blocked.

@bpolaszek, do you know why?

Thanks