### PR TITLE
chore: upgrade PHPStan to v2 for Symfony 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
         "post-update-cmd": [
             "bin/freddie cache:clear"
         ],
-        "phpstan:analyze": "vendor/bin/phpstan analyse --memory-limit=1G",
+        "phpstan:analyze": "vendor/bin/phpstan analyse",
         "linter:check": "vendor/bin/phpcs",
         "linter:fix": "vendor/bin/phpcbf",
         "tests:unit:run": "vendor/bin/pest --testsuite='Unit tests'",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "require-dev": {
         "clue/reactphp-eventsource": "^1.0.0",
         "pestphp/pest": "^4.0",
-        "phpstan/phpstan": "^1.2",
+        "phpstan/phpstan": "^2.1",
         "react/child-process": "^0.6.4",
         "ringcentral/psr7": "^1.3",
         "squizlabs/php_codesniffer": "^3.6",
@@ -80,7 +80,7 @@
         "post-update-cmd": [
             "bin/freddie cache:clear"
         ],
-        "phpstan:analyze": "vendor/bin/phpstan analyse",
+        "phpstan:analyze": "vendor/bin/phpstan analyse --memory-limit=1G",
         "linter:check": "vendor/bin/phpcs",
         "linter:fix": "vendor/bin/phpcbf",
         "tests:unit:run": "vendor/bin/pest --testsuite='Unit tests'",

--- a/src/Security/JWT/Extractor/CookieTokenExtractor.php
+++ b/src/Security/JWT/Extractor/CookieTokenExtractor.php
@@ -8,7 +8,6 @@ use Psr\Http\Message\ServerRequestInterface;
 
 use function array_map;
 use function implode;
-use function is_string;
 use function strlen;
 
 final readonly class CookieTokenExtractor implements PSR7TokenExtractorInterface
@@ -37,7 +36,7 @@ final readonly class CookieTokenExtractor implements PSR7TokenExtractorInterface
             ),
         );
 
-        if (!is_string($token) || strlen($token) < 41) {
+        if (strlen($token) < 41) {
             return null;
         }
 


### PR DESCRIPTION
PHPStan `^1.2` (2021) can't parse `symfony/console` 8.x, so it reports `ServeCommand extends unknown class Command` and cascades. 

- Bump `phpstan/phpstan` `^1.2` → `^2.1` (parses Symfony 8 / PHP 8.4 correctly).
- Remove `is_string()` on `implode()`'s always-string result in `CookieTokenExtractor`