### PR TITLE
feat: send periodic SSE heartbeats to reap half-open connections

### DIFF
--- a/src/DependencyInjection/services.php
+++ b/src/DependencyInjection/services.php
@@ -44,11 +44,13 @@ return static function (ContainerConfigurator $container) {
     $params = $container->parameters();
     $params->set('env(TRANSPORT_DSN)', 'php://default');
     $params->set('env(ALLOW_ANONYMOUS)', Hub::DEFAULT_OPTIONS['allow_anonymous']);
+    $params->set('env(HEARTBEAT_INTERVAL)', Hub::DEFAULT_OPTIONS['heartbeat_interval']);
     $params->set('env(JWT_SECRET_KEY)', '!ChangeMe!');
     $params->set('env(JWT_PUBLIC_KEY)', null);
     $params->set('env(JWT_ALGORITHM)', 'HS256');
     $params->set('transport_dsn', '%env(resolve:TRANSPORT_DSN)%');
     $params->set('allow_anonymous', '%env(bool:ALLOW_ANONYMOUS)%');
+    $params->set('heartbeat_interval', '%env(float:HEARTBEAT_INTERVAL)%');
 
     $services = $container->services();
     $services
@@ -100,7 +102,10 @@ return static function (ContainerConfigurator $container) {
 
     $services
         ->set(Hub::class)
-        ->arg('$options', ['allow_anonymous' => param('allow_anonymous')]);
+        ->arg('$options', [
+            'allow_anonymous' => param('allow_anonymous'),
+            'heartbeat_interval' => param('heartbeat_interval'),
+        ]);
 
     $services->alias(HubInterface::class, Hub::class);
 

--- a/src/Hub/Controller/SubscribeController.php
+++ b/src/Hub/Controller/SubscribeController.php
@@ -12,6 +12,7 @@ use Freddie\Subscription\Subscriber;
 use Lcobucci\JWT\UnencryptedToken;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use React\EventLoop\Loop;
 use React\Http\Message\Response;
 use React\Stream\ReadableStreamInterface;
 use React\Stream\ThroughStream;
@@ -25,6 +26,12 @@ use function React\Async\async;
 
 final class SubscribeController implements HubControllerInterface
 {
+    /**
+     * SSE comment line: keeps proxies from closing idle connections and forces
+     * the TCP stack to detect half-open peers so their subscribers get reaped.
+     */
+    private const HEARTBEAT = ":\n";
+
     private HubInterface $hub;
 
     public function setHub(HubInterface $hub): self
@@ -81,6 +88,15 @@ final class SubscribeController implements HubControllerInterface
                 $subscriber->setCallback($callback);
                 $this->hub->subscribe($subscriber);
                 $stream->on('close', fn() => $this->hub->unsubscribe($subscriber));
+
+                $heartbeatInterval = (float) $this->hub->getOption('heartbeat_interval');
+                if ($heartbeatInterval > 0) {
+                    $timer = Loop::addPeriodicTimer(
+                        $heartbeatInterval,
+                        fn() => $stream->write(self::HEARTBEAT),
+                    );
+                    $stream->on('close', fn() => Loop::cancelTimer($timer));
+                }
             }
         )();
 

--- a/src/Hub/Hub.php
+++ b/src/Hub/Hub.php
@@ -24,6 +24,7 @@ final class Hub implements HubInterface
 {
     public const DEFAULT_OPTIONS = [
         'allow_anonymous' => true,
+        'heartbeat_interval' => 40.0,
     ];
 
     /**
@@ -47,6 +48,7 @@ final class Hub implements HubInterface
         $resolver = new OptionsResolver();
         $resolver->setDefaults(self::DEFAULT_OPTIONS);
         $resolver->setAllowedTypes('allow_anonymous', 'bool');
+        $resolver->setAllowedTypes('heartbeat_interval', ['int', 'float']);
         $this->options = $resolver->resolve($options);
         foreach ($controllers as $controller) {
             $controller->setHub($this);

--- a/tests/Unit/Hub/Controller/DeadStreamStub.php
+++ b/tests/Unit/Hub/Controller/DeadStreamStub.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Freddie\Tests\Unit\Hub\Controller;
+
+use Evenement\EventEmitterTrait;
+use LogicException;
+use Pest\Exceptions\ShouldNotHappen;
+use React\Stream\ReadableStreamInterface;
+use React\Stream\WritableStreamInterface;
+
+/**
+ * Models a "gone" client (a half-open TCP socket whose peer vanished without
+ * FIN/RST): the first write to the dead peer fails and, like React's
+ * WritableResourceStream::handleWrite(), closes the stream (emitting 'close').
+ */
+final class DeadStreamStub implements WritableStreamInterface, ReadableStreamInterface
+{
+    use EventEmitterTrait;
+
+    /**
+     * @var array<string>
+     */
+    public array $writes = [];
+
+    private bool $closed = false;
+
+    public function write($data): bool
+    {
+        $this->writes[] = $data;
+        $this->close();
+
+        return false;
+    }
+
+    public function isReadable(): bool
+    {
+        return !$this->closed;
+    }
+
+    public function pause(): void
+    {
+        throw new ShouldNotHappen(new LogicException(__METHOD__));
+    }
+
+    public function resume(): void
+    {
+        throw new ShouldNotHappen(new LogicException(__METHOD__));
+    }
+
+    public function pipe(WritableStreamInterface $dest, array $options = []): ?WritableStreamInterface
+    {
+        throw new ShouldNotHappen(new LogicException(__METHOD__));
+    }
+
+    public function isWritable(): bool
+    {
+        return !$this->closed;
+    }
+
+    public function end($data = null): void
+    {
+        throw new ShouldNotHappen(new LogicException(__METHOD__));
+    }
+
+    public function close(): void
+    {
+        if ($this->closed) {
+            return;
+        }
+
+        $this->closed = true;
+        $this->emit('close');
+    }
+}

--- a/tests/Unit/Hub/Controller/SubscribeControllerTest.php
+++ b/tests/Unit/Hub/Controller/SubscribeControllerTest.php
@@ -195,7 +195,7 @@ it('unsubscribes from transport whenever connection closes', function () {
     expect($stream->storage[0])->toBe((string) $hello);
 });
 
-it('writes periodic heartbeats and stops them when the connection closes', function () {
+it('writes periodic heartbeats and cancels the timer when the stream is closed', function () {
     $controller = new SubscribeController();
     $controller->setHub(new Hub(options: ['heartbeat_interval' => 0.01]));
     $stream = new ThroughStreamStub();
@@ -210,17 +210,44 @@ it('writes periodic heartbeats and stops them when the connection closes', funct
 
     $beats = fn () => count(array_filter($stream->storage, fn ($chunk) => ":\n" === $chunk));
 
-    // Then: heartbeats were written
+    // Then: heartbeats were written on the interval
     $before = $beats();
     expect($before)->toBeGreaterThanOrEqual(1);
 
-    // When: the connection closes
+    // When: the stream is closed (e.g. a graceful client disconnect)
     $stream->close();
     Loop::addTimer(0.025, fn () => Loop::stop());
     Loop::run();
 
-    // Then: no further heartbeats are written (timer cancelled on close)
+    // Then: the timer was cancelled, so no further heartbeats are written
     expect($beats())->toBe($before);
+});
+
+// The actual reaping of a "gone" client is delegated to React/TCP: a heartbeat
+// write to a half-open socket eventually fails, React emits 'close', and the
+// existing 'close' handler unsubscribes. DeadStreamStub simulates that failed
+// write so we can assert the Freddie-side chain (write -> close -> unsubscribe).
+it('reaps a gone client when a heartbeat write closes the dead stream', function () {
+    $transport = new PHPTransport(size: 1000);
+    $controller = new SubscribeController();
+    $controller->setHub(new Hub(transport: $transport, options: ['heartbeat_interval' => 0.01]));
+    $stream = new DeadStreamStub();
+
+    // Given: a subscriber whose client has silently gone away
+    $request = new ServerRequest('GET', '/.well-known/mercure?topic=/foo');
+    $controller($request, $stream);
+
+    // When: the heartbeat fires and its write hits the dead peer
+    Loop::addTimer(0.03, fn () => Loop::stop());
+    Loop::run();
+
+    // Then: a single heartbeat was attempted, which closed the stream and
+    // cancelled the timer (no repeated writes)
+    expect($stream->writes)->toBe([":\n"]);
+
+    // And: the subscriber was unsubscribed, so a later update is not delivered
+    $transport->publish(new Update(['/foo'], new Message(data: 'after')));
+    expect($stream->writes)->toBe([":\n"]);
 });
 
 it('does not write heartbeats when the interval is zero', function () {

--- a/tests/Unit/Hub/Controller/SubscribeControllerTest.php
+++ b/tests/Unit/Hub/Controller/SubscribeControllerTest.php
@@ -194,3 +194,48 @@ it('unsubscribes from transport whenever connection closes', function () {
     expect($stream->storage)->toHaveCount(1);
     expect($stream->storage[0])->toBe((string) $hello);
 });
+
+it('writes periodic heartbeats and stops them when the connection closes', function () {
+    $controller = new SubscribeController();
+    $controller->setHub(new Hub(options: ['heartbeat_interval' => 0.01]));
+    $stream = new ThroughStreamStub();
+
+    // Given
+    $request = new ServerRequest('GET', '/.well-known/mercure?topic=/foo');
+
+    // When: a few heartbeats have time to fire
+    $controller($request, $stream);
+    Loop::addTimer(0.025, fn () => Loop::stop());
+    Loop::run();
+
+    $beats = fn () => count(array_filter($stream->storage, fn ($chunk) => ":\n" === $chunk));
+
+    // Then: heartbeats were written
+    $before = $beats();
+    expect($before)->toBeGreaterThanOrEqual(1);
+
+    // When: the connection closes
+    $stream->close();
+    Loop::addTimer(0.025, fn () => Loop::stop());
+    Loop::run();
+
+    // Then: no further heartbeats are written (timer cancelled on close)
+    expect($beats())->toBe($before);
+});
+
+it('does not write heartbeats when the interval is zero', function () {
+    $controller = new SubscribeController();
+    $controller->setHub(new Hub(options: ['heartbeat_interval' => 0.0]));
+    $stream = new ThroughStreamStub();
+
+    // Given
+    $request = new ServerRequest('GET', '/.well-known/mercure?topic=/foo');
+
+    // When
+    $controller($request, $stream);
+    Loop::addTimer(0.025, fn () => Loop::stop());
+    Loop::run();
+
+    // Then
+    expect($stream->storage)->toBe([]);
+});


### PR DESCRIPTION
Idle SSE subscribers whose client dies silently (mobile drop, laptop sleep, NAT/proxy timeout) never emit a stream `close`, so they leak in the transport's topic index (~kernel keepalive, ~2h) and keep getting re-matched on every publish, wasting CPU. 

This adds a periodic SSE heartbeat (`:\n` SSE comment) per subscription. It (a) keeps live connections open through reverse-proxy idle timeouts and (b) forces a TCP write on half-open peers so the kernel detects the dead connection and emits `close`, triggering the existing unsubscribe path.

- New `heartbeat_interval` hub option (default 40s), configurable via `HEARTBEAT_INTERVAL` env; `0` disables.
